### PR TITLE
Make Python 3 happy by using a print function instead of a print statement.

### DIFF
--- a/flask_uwsgi_websocket/websocket.py
+++ b/flask_uwsgi_websocket/websocket.py
@@ -87,7 +87,7 @@ class WebSocket(object):
         uwsgi_args = ' '.join(['--{0} {1}'.format(k,v) for k,v in kwargs.items()])
         args = 'uwsgi --http {0}:{1} --http-websockets {2} --wsgi {3}'.format(host, port, uwsgi_args, app)
 
-        print args
+        print(args)
 
         # set enviromental variable to trigger adding debug middleware
         if self.app.debug or debug:


### PR DESCRIPTION
I've been playing around with this library using Python 3.3.5. I'm not sure what the overall state of Python 3 support is, since you say nothing about Python 3 in your README. So far I've only encountered this minor issue.
