### PR TITLE
Prevents `GeventWebSocketClient.send` from blocking on full queues.

### DIFF
--- a/flask_uwsgi_websocket/_gevent.py
+++ b/flask_uwsgi_websocket/_gevent.py
@@ -47,7 +47,7 @@ class GeventWebSocketMiddleware(WebSocketMiddleware):
 
         # setup events
         send_event = Event()
-        send_queue = Queue(maxsize=1)
+        send_queue = Queue()
 
         recv_event = Event()
         recv_queue = Queue(maxsize=1)
@@ -79,7 +79,8 @@ class GeventWebSocketMiddleware(WebSocketMiddleware):
             if send_event.is_set():
                 try:
                     uwsgi.websocket_send(send_queue.get())
-                    send_event.clear()
+                    if send_queue.qsize() == 0:
+                        send_event.clear()
                 except IOError:
                     client.connected = False
 


### PR DESCRIPTION
If one wishes to have a process which stores references to a number of connections, and then sends out messages to them based on events, then the maximum queue length is problematic, since it means that if any messages have not been sent for a particular connection, then any future send calls to that connection will block until the first message has been sent.

Concretely, the big issue that we've seen is that it is possible that between calling `send` and the message actually being sent, the connection can be dropped. If two calls are made to send in this period of time the second call will hang forever (even with a check that `connected` is True).

In the current implementation, there's no guarantee of when a call to `send` will actually result in sending the message to the client. As a consequence, there doesn't seem to be any benefit to blocking subsequent calls (since we're using a Queue, message order will be preserved in any case).
