### PR TITLE
Return normal Flask response for HTTP requests

### DIFF
--- a/flask_uwsgi_websocket/_gevent.py
+++ b/flask_uwsgi_websocket/_gevent.py
@@ -39,7 +39,7 @@ class GeventWebSocketMiddleware(WebSocketMiddleware):
     def __call__(self, environ, start_response):
         handler = self.websocket.routes.get(environ['PATH_INFO'])
 
-        if not handler:
+        if not handler or 'HTTP_SEC_WEBSOCKET_KEY' not in environ:
             return self.wsgi_app(environ, start_response)
 
         # do handshake

--- a/flask_uwsgi_websocket/websocket.py
+++ b/flask_uwsgi_websocket/websocket.py
@@ -50,11 +50,11 @@ class WebSocketMiddleware(object):
     def __call__(self, environ, start_response):
         handler = self.websocket.routes.get(environ['PATH_INFO'])
 
-        if handler:
-            uwsgi.websocket_handshake(environ['HTTP_SEC_WEBSOCKET_KEY'], environ.get('HTTP_ORIGIN', ''))
-            handler(self.client(environ, uwsgi.connection_fd(), self.websocket.timeout))
-        else:
+        if not handler or 'HTTP_SEC_WEBSOCKET_KEY' not in environ:
             return self.wsgi_app(environ, start_response)
+
+        uwsgi.websocket_handshake(environ['HTTP_SEC_WEBSOCKET_KEY'], environ.get('HTTP_ORIGIN', ''))
+        handler(self.client(environ, uwsgi.connection_fd(), self.websocket.timeout))
 
 
 class WebSocket(object):


### PR DESCRIPTION
Tiny little check for missing `HTTP_SEC_WEBSOCKET_KEY` headers, which would imply a normal HTTP connection; previously caused an exception (below) - Flask should provide a 404/similar response with this change.

```
*** running gevent loop engine [addr:0x10cc69f70] ***
Python auto-reloader enabled
Traceback (most recent call last):
  File "/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/flask_uwsgi_websocket/_gevent.py", line 46, in __call__
    uwsgi.websocket_handshake(environ.get('HTTP_SEC_WEBSOCKET_KEY'), environ.get('HTTP_ORIGIN', ''))
TypeError: must be string or read-only buffer, not None
```
