### PR TITLE
Added UWSGI_WEBSOCKET_AGGRESSIVE_PATCH configuration.

### DIFF
--- a/flask_uwsgi_websocket/_gevent.py
+++ b/flask_uwsgi_websocket/_gevent.py
@@ -2,7 +2,6 @@ from gevent import killall, sleep, spawn, wait
 from gevent.event import Event
 from gevent.queue import Queue, Empty
 from gevent.select import select
-from gevent.monkey import patch_all; patch_all()
 import uuid
 
 from .websocket import WebSocket, WebSocketClient, WebSocketMiddleware

--- a/flask_uwsgi_websocket/websocket.py
+++ b/flask_uwsgi_websocket/websocket.py
@@ -2,6 +2,7 @@ import os
 import sys
 import uuid
 from ._uwsgi import uwsgi
+from gevent.monkey import patch_all
 
 
 class WebSocketClient(object):
@@ -97,6 +98,9 @@ class WebSocket(object):
 
     def init_app(self, app):
         self.app = app
+
+        aggressive_patch = app.config.get('UWSGI_WEBSOCKET_AGGRESSIVE_PATCH', True)
+        patch_all(aggressive=aggressive_patch)
 
         if os.environ.get('FLASK_UWSGI_DEBUG'):
             from werkzeug.debug import DebuggedApplication


### PR DESCRIPTION
Some libraries uses select.poll method that gevent patch_all removes by
default.

I had some troubles with matplotlib (apparently the Agg backend doesn't work well because gevent.monkey.patch_all removes "poll" method from "select" module).