### PR TITLE
This allows you to use non-gevent again

### DIFF
--- a/flask_uwsgi_websocket/_gevent.py
+++ b/flask_uwsgi_websocket/_gevent.py
@@ -2,6 +2,7 @@ from gevent import spawn, wait
 from gevent.event import Event
 from gevent.queue import Queue, Empty
 from gevent.select import select
+from gevent.monkey import patch_all
 import uuid
 
 from .websocket import WebSocket, WebSocketMiddleware

--- a/flask_uwsgi_websocket/websocket.py
+++ b/flask_uwsgi_websocket/websocket.py
@@ -2,7 +2,6 @@ import os
 import sys
 import uuid
 from ._uwsgi import uwsgi
-from gevent.monkey import patch_all
 
 
 class WebSocketClient(object):
@@ -106,8 +105,10 @@ class WebSocket(object):
     def init_app(self, app):
         self.app = app
 
-        aggressive_patch = app.config.get('UWSGI_WEBSOCKET_AGGRESSIVE_PATCH', True)
-        patch_all(aggressive=aggressive_patch)
+        if self.middleware.__name__ == "GeventWebSocketMiddleware":
+            from gevent import patch_all
+            aggressive_patch = app.config.get('UWSGI_WEBSOCKET_AGGRESSIVE_PATCH', True)
+            patch_all(aggressive=aggressive_patch)
 
         if os.environ.get('FLASK_UWSGI_DEBUG'):
             from werkzeug.debug import DebuggedApplication


### PR DESCRIPTION
I'm using string comparison to completely avoid any dependency on gevent stuff here and the class name shouldn't change too often so it's quite safe.

Without this patch, operating without gevent wasn't possible as patch_all was imported from it unconditionally.

Using gevent is sadly not possible on Python 3 so this is pretty much required.