### PR TITLE
Don't hard-code path to uwsgi

### DIFF
--- a/flask_uwsgi_websocket/websocket.py
+++ b/flask_uwsgi_websocket/websocket.py
@@ -95,7 +95,9 @@ class WebSocket(object):
 
         # constructing uwsgi arguments
         uwsgi_args = ' '.join(['--{0} {1}'.format(k,v) for k,v in kwargs.items()])
-        args = 'uwsgi --http {0}:{1} --http-websockets {2} --wsgi {3}'.format(host, port, uwsgi_args, app)
+
+        uwsgi_executable = "{0}/uwsgi".format(os.path.dirname(sys.executable))
+        args = '{0} --http {1}:{2} --http-websockets {3} --wsgi {4}'.format(uwsgi_executable, host, port, uwsgi_args, app)
 
         # set enviromental variable to trigger adding debug middleware
         if self.app.debug or debug:


### PR DESCRIPTION
Hard-coding uwsgi is bad because that makes the shell query its PATH but we don't always have a PATH nor do we have a shell but we ALWAYS have a Python interpreter and the uwsgi binary next to this specific interpreter (we might have more than one in PATH and also multiple uwsgi in PATH) is absolutely the right one. We don't want to use a system-installed uwsgi with a local interpreter now do we?