### PR TITLE
return an (empty) list as per the wsgi spec

### DIFF
--- a/flask_uwsgi_websocket/websocket.py
+++ b/flask_uwsgi_websocket/websocket.py
@@ -65,6 +65,7 @@ class WebSocketMiddleware(object):
 
         uwsgi.websocket_handshake(environ['HTTP_SEC_WEBSOCKET_KEY'], environ.get('HTTP_ORIGIN', ''))
         handler(self.client(environ, uwsgi.connection_fd(), self.websocket.timeout))
+        return []
 
 
 class WebSocket(object):


### PR DESCRIPTION
I noticed that when my websocket endpoint function returned, I would see "TypeError: 'NoneType' object is not iterable" pop up in my UWSGI server logs.  I did some investigation and noticed that in Flask-Sockets, the middleware's callable implementation returns an empty list, which apparently is part of the WSGI spec:

https://github.com/kennethreitz/flask-sockets/blob/master/flask_sockets.py#L40.

It's not a big deal since it seems like this library is geared toward gevent anyways, but I thought it would save someone out there a headache.  Here is the quick fix code I used to test it successfully:

```python
from flask import Flask
from flask.ext.uwsgi_websocket import WebSocket, WebSocketMiddleware

# so that uwsgi will stop printing NoneType errors...
class WebSocketMiddlewareFixed(WebSocketMiddleware):
    def __call__(self, env, sr):
        super(WebSocketMiddlewareFixed, self).__call__(env, sr)
        return []

class WebSocketFixed(WebSocket):
    middleware = WebSocketMiddlewareFixed


app = Flask(__name__)
ws = WebSocketFixed(app)

# test endpoint
@ws.route('/ws/ping')
def echo(ws):
    ws.send("ping success")

@ws.route('/ws/metrics')
def metrics(ws):
    pass
```