### PR TITLE
Enable url processors and Blueprint support

### DIFF
--- a/examples/chat-gevent/chat.py
+++ b/examples/chat-gevent/chat.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from collections import deque
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 from flask.ext.uwsgi_websocket import GeventWebSocket
 
 app = Flask(__name__)
@@ -11,7 +11,11 @@ backlog = deque(maxlen=10)
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    uri = '%s://%s/%s' % \
+        (request.environ['wsgi.url_scheme'] == 'https' and 'wss' or 'ws', \
+        request.headers['host'], 'websocket')
+    return render_template('index.html', websocket_uri = uri)
+
 
 @ws.route('/websocket')
 def chat(ws):

--- a/examples/chat-gevent/templates/index.html
+++ b/examples/chat-gevent/templates/index.html
@@ -22,7 +22,7 @@
               }
           }
 
-          var ws = new WebSocket('ws://127.0.0.1:5000/websocket');
+          var ws = new WebSocket('{{ websocket_uri }}');
           ws.onopen = function(evt) {
             showMessage('Connected to chat.')
           }

--- a/examples/echo-gevent/echo.py
+++ b/examples/echo-gevent/echo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 from flask.ext.uwsgi_websocket import GeventWebSocket
 
 app = Flask(__name__)
@@ -7,7 +7,11 @@ ws = GeventWebSocket(app)
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    uri = '%s://%s/%s' % \
+        (request.environ['wsgi.url_scheme'] == 'https' and 'wss' or 'ws', \
+        request.headers['host'], 'websocket')
+    return render_template('index.html', websocket_uri = uri)
+
 
 @ws.route('/websocket')
 def echo(ws):

--- a/examples/echo-gevent/templates/index.html
+++ b/examples/echo-gevent/templates/index.html
@@ -17,7 +17,7 @@
                     $('#messages').append("<li>Your browser doesn't support WebSockets.</li>");
                 }
             }
-            ws = new WebSocket('ws://127.0.0.1:5000/websocket');
+            ws = new WebSocket('{{ websocket_uri }}');
             ws.onopen = function(evt) {
                 $('#messages').append('<li>WebSocket connection opened.</li>');
             }

--- a/examples/echo/echo.py
+++ b/examples/echo/echo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 from flask.ext.uwsgi_websocket import WebSocket
 
 app = Flask(__name__)
@@ -7,7 +7,10 @@ ws = WebSocket(app)
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    uri = '%s://%s/%s' % \
+        (request.environ['wsgi.url_scheme'] == 'https' and 'wss' or 'ws', \
+        request.headers['host'], 'websocket')
+    return render_template('index.html', websocket_uri = uri)
 
 @ws.route('/websocket')
 def echo(ws):

--- a/examples/echo/templates/index.html
+++ b/examples/echo/templates/index.html
@@ -17,7 +17,7 @@
                     $('#messages').append("<li>Your browser doesn't support WebSockets.</li>");
                 }
             }
-            var ws = new WebSocket('ws://127.0.0.1:5000/websocket');
+            var ws = new WebSocket('{{ websocket_uri }}');
             ws.onopen = function(evt) {
                 $('#messages').append('<li>WebSocket connection opened.</li>');
             }

--- a/flask_uwsgi_websocket/websocket.py
+++ b/flask_uwsgi_websocket/websocket.py
@@ -66,8 +66,8 @@ class WebSocketMiddleware(object):
             endpoint, args = urls.match()
             print(endpoint, args)
             handler = self.websocket.view_functions[endpoint]
-        except HTTPException as e:
-            raise e
+        except HTTPException:
+            handler = None
 
         if not handler or 'HTTP_SEC_WEBSOCKET_KEY' not in environ:
             return self.wsgi_app(environ, start_response)


### PR DESCRIPTION
By employing werkzeug.routing in WebSocketMiddleware, using a flask-style url processor was made possible. I merged register_blueprint method from flask.app so that websocket routes could be defined in separated files with Blueprints.