### PR TITLE
Python 3 bug fix.

### DIFF
--- a/flask_uwsgi_websocket/__init__.py
+++ b/flask_uwsgi_websocket/__init__.py
@@ -31,7 +31,7 @@ class AsyncioNotAvailable(Exception):
 try:
     assert sys.version_info > (3,4)
     from ._asyncio import *
-except AssertionError, ImportError:
+except (AssertionError, ImportError):
     class AsyncioWebSocket(object):
         def __init__(self, *args, **kwargs):
             raise AsyncioNotAvailable("Asyncio should be enabled at uwsgi compile time. Try: `UWSGI_PROFILE=asyncio pip install uwsgi`.")


### PR DESCRIPTION
Comma delimited Exceptions are deprecated in python 3