### PR TITLE
Merge methods if methods is given in options

### DIFF
--- a/flask_uwsgi_websocket/websocket.py
+++ b/flask_uwsgi_websocket/websocket.py
@@ -131,6 +131,9 @@ class WebSocket(object):
         options['endpoint'] = endpoint
         # supposed to be GET
         methods = set(('GET', ))
+        if 'methods' in options:
+            methods = methods.union(options['methods'])
+            options.pop('methods')
         provide_automatic_options = False
 
         rule = Rule(rule, methods=methods, **options)


### PR DESCRIPTION
If methods are also given in options, the two arguments will clash, so methods has to be removed from options.