### PR TITLE
Remove setup.py dependency on uwsgi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     platforms='any',
     install_requires=[
         'Flask',
-        'uwsgi',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
This might at first sound like a silly request, but there are many ways to install uwsgi, and not all are recognized by pip. If I have uwsgi installed through a package manager (`apt install uwsgi uwsgi-plugin-python3` on Debian), I don't want to install another copy of uwsgi when I install `Flask-uWSGI-WebSocket`. Especially since uwsgi installation through pip is sometimes non-trivial, requiring a compiler and several libraries to be found.

With pip, I can use `pip install Flask-uWSGI-WebSocket --no-deps` to avoid uwsgi, but with `pipenv` no such flag seems to be available, so this is why I'm suggesting to remove `uwsgi` from setup.py.