### PR TITLE
generate a request context for all the WS handler exec environments

### DIFF
--- a/flask_uwsgi_websocket/_gevent.py
+++ b/flask_uwsgi_websocket/_gevent.py
@@ -75,7 +75,10 @@ class GeventWebSocketMiddleware(WebSocketMiddleware):
                              self.websocket.timeout)
 
         # spawn handler
-        handler = spawn(handler, client, **args)
+        def wrapped_handler():
+            with self.websocket.app.request_context(environ):
+                return handler(client, **args)
+        handler = spawn(wrapped_handler)
 
         # spawn recv listener
         def listener(client):

--- a/flask_uwsgi_websocket/websocket.py
+++ b/flask_uwsgi_websocket/websocket.py
@@ -69,9 +69,10 @@ class WebSocketMiddleware(object):
 
         if not handler or 'HTTP_SEC_WEBSOCKET_KEY' not in environ:
             return self.wsgi_app(environ, start_response)
-
         uwsgi.websocket_handshake(environ['HTTP_SEC_WEBSOCKET_KEY'], environ.get('HTTP_ORIGIN', ''))
-        handler(self.client(environ, uwsgi.connection_fd(), self.websocket.timeout), **args)
+        app = self.websocket.app
+        with app.request_context(environ):
+            handler(self.client(environ, uwsgi.connection_fd(), self.websocket.timeout), **args)
         return []
 
 


### PR DESCRIPTION
Inside of websocket handlers, the flask request context doesn't currently exist. This makes it difficult to do things like access cookies, and also breaks compatibility with other flask plugins (like flask-login, in my case, which pre-loads user information, and assumes the request context is valid).

In my own app, this seems to work. Looks like activity on this repo is low, but I thought I'd offer the PR in case it might be useful to other users of this repo & it makes sense to install unconditionally.